### PR TITLE
feat: add user orders endpoint with pagination support

### DIFF
--- a/src/orders/dto/order-summary.dto.ts
+++ b/src/orders/dto/order-summary.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class OrderSummaryDto {
+  @ApiProperty({ example: 'ORD-2024-001234' })
+  order_id: string;
+
+  @ApiProperty({ example: 'confirmed' })
+  status: string;
+
+  @ApiProperty({ example: 1576.77 })
+  total: number;
+
+  @ApiProperty({ example: '2024-08-04T10:25:00Z' })
+  created_at: Date;
+}
+export class PaginationMetaDto {
+  @ApiProperty({ example: 1 })
+  page: number;
+
+  @ApiProperty({ example: 10 })
+  limit: number;
+
+  @ApiProperty({ example: 1 })
+  total: number;
+
+  @ApiProperty({ example: false })
+  has_more: boolean;
+}
+
+export class OrdersPaginatedResponseDto {
+  @ApiProperty({ type: [OrderSummaryDto] })
+  orders: OrderSummaryDto[];
+
+  @ApiProperty({ type: PaginationMetaDto })
+  pagination: PaginationMetaDto;
+}

--- a/src/orders/dto/query.dto.ts
+++ b/src/orders/dto/query.dto.ts
@@ -1,0 +1,4 @@
+export class PaginationDto {
+  page: number;
+  limit: number;
+}

--- a/src/orders/mapper/orders.mapper.ts
+++ b/src/orders/mapper/orders.mapper.ts
@@ -1,5 +1,6 @@
 import { Order } from '../orders.entity';
 import { OrderResponseDto } from '../dto/orders-response.dto';
+import { OrderSummaryDto } from '../dto/order-summary.dto';
 
 export default class OrderMapper {
   static toResponse(order: Order): OrderResponseDto {
@@ -10,5 +11,15 @@ export default class OrderMapper {
       estimated_total: order.pricing.total,
       created_at: order.created_at,
     };
+  }
+  static ordersToUsers(orders: Order[]): OrderSummaryDto[] {
+    return orders.map(
+      (order: Order): OrderSummaryDto => ({
+        order_id: order.order_id,
+        status: order.status,
+        total: order.pricing.total,
+        created_at: order.created_at
+      }),
+    );
   }
 }

--- a/src/orders/orders.module.ts
+++ b/src/orders/orders.module.ts
@@ -7,6 +7,7 @@ import { ProductModule } from '@/products/product.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Order } from './orders.entity';
 import { MONGO_DB_TYPE_ORM_NAME } from '@/common/constants';
+import { UserController } from './users.controller';
 
 @Module({
   imports: [
@@ -14,7 +15,7 @@ import { MONGO_DB_TYPE_ORM_NAME } from '@/common/constants';
     LoggerProviderModule,
     ProductModule,
   ],
-  controllers: [OrdersController],
+  controllers: [OrdersController, UserController],
   providers: [OrdersService],
   exports: [OrdersService],
 })

--- a/src/orders/users.controller.ts
+++ b/src/orders/users.controller.ts
@@ -1,0 +1,46 @@
+import { LoggerProviderService } from '@/providers/logger/logger.provider.service';
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { OrdersService } from './orders.service';
+import { PaginationDto } from './dto/query.dto';
+import { OrdersPaginatedResponseDto } from './dto/order-summary.dto';
+import { ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+@ApiTags('Users') // Agrupa en Swagger
+@Controller('users')
+export class UserController {
+  private context = UserController.name;
+
+  constructor(
+    private readonly logger: LoggerProviderService,
+    private readonly orderService: OrdersService,
+  ) {}
+
+  @Get('/:user_id')
+  @ApiParam({
+    name: 'user_id',
+    description: 'User identifier',
+    example: 'user_12345',
+  })
+  @ApiQuery({ name: 'page', required: false, example: 1, type: Number })
+  @ApiQuery({ name: 'limit', required: false, example: 10, type: Number })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated list of user orders',
+    type: OrdersPaginatedResponseDto,
+  })
+  async getOrdersByUser(
+    @Param('user_id') userId: string,
+    @Query() query: PaginationDto,
+  ): Promise<OrdersPaginatedResponseDto> {
+    this.logger.log(
+      this.context,
+      `Fetching orders for user_id=${userId} with pagination ${JSON.stringify(query)}`,
+    );
+
+    const response = await this.orderService.findByUser(userId, query);
+
+    this.logger.log(this.context, `Found ${response.orders.length} orders for user_id=${userId}`);
+
+    return response;
+  }
+}


### PR DESCRIPTION
- Created DTOs for order summary and pagination (order-summary.dto.ts, query.dto.ts)
- Added new users.controller to expose /users/:user_id endpoint
- Integrated mapper and service logic to return paginated orders
- Registered controller in orders.module